### PR TITLE
Replaced /etc with /etc/conf.d for pf.conf

### DIFF
--- a/init.d/pf.in
+++ b/init.d/pf.in
@@ -10,7 +10,7 @@
 # except according to the terms contained in the LICENSE file.
 
 name="Packet Filter"
-: ${pf_conf:=${pf_rules:-/etc/pf.conf}}
+: ${pf_conf:=${pf_rules:-/etc/conf.d/pf.conf}}
 required_files=$pf_conf
 
 extra_commands="checkconfig showstatus"


### PR DESCRIPTION
OpenRC uses /etc/conf.d for configuration files. Aligning with OpenRC practice of using /etc/conf.d.